### PR TITLE
Update glob

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "main": "./lib/htmlclean.js",
   "dependencies": {
     "commander": "^2.6.0",
-    "glob": "~4.4.0"
+    "glob": "^7.1.1"
   },
   "homepage": "https://github.com/anseki/htmlclean",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "commander": "^2.6.0",
-    "glob": "~4.4.0"
+    "glob": "^7.1.1"
   },
   "homepage": "https://github.com/anseki/htmlclean",
   "repository": {


### PR DESCRIPTION
Hi, could you check this.

There is a RegExp DoS issue in `minimatch@2.0.10` on which `glob@4.4.2` depends.

Therefore, the following warning will appear at `npm install` .

```
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

Thanks.